### PR TITLE
Fix: onFinished/onFinishing does not get the right currentIndex param.

### DIFF
--- a/src/privates.js
+++ b/src/privates.js
@@ -720,7 +720,7 @@ function paginationClickHandler(event)
     switch (href.substring(href.lastIndexOf("#")))
     {
         case "#finish":
-            finishStep(wizard, options, state);
+            finishStep(wizard, state);
             break;
 
         case "#next":


### PR DESCRIPTION
In current version, when listen to onFinished/onFinishing with function like function(event, currentIndex), the currentIndex is always undefined.

This is caused by the typo fixed in the commmit.
