### PR TITLE
Adds support for step titles nested in contents

### DIFF
--- a/src/privates.js
+++ b/src/privates.js
@@ -87,8 +87,8 @@ function addStepToCache(wizard, step)
 
 function analyzeData(wizard, options, state)
 {
-    var stepTitles = wizard.children(options.headerTag),
-        stepContents = wizard.children(options.bodyTag);
+    var stepTitles = wizard.find(options.headerTag),
+        stepContents = wizard.find(options.bodyTag);
 
     // Validate content
     if (stepTitles.length > stepContents.length)
@@ -957,8 +957,8 @@ function render(wizard, options, state)
         verticalCssClass = (orientation === stepsOrientation.vertical) ? " vertical" : "",
         contentWrapper = $(format(wrapperTemplate, options.contentContainerTag, "content " + options.clearFixCssClass, wizard.html())),
         stepsWrapper = $(format(wrapperTemplate, options.stepsContainerTag, "steps " + options.clearFixCssClass, "<ul role=\"tablist\"></ul>")),
-        stepTitles = contentWrapper.children(options.headerTag),
-        stepContents = contentWrapper.children(options.bodyTag);
+        stepTitles = contentWrapper.find(options.headerTag),
+        stepContents = contentWrapper.find(options.bodyTag);
 
     // Transform the wizard wrapper and remove the inner HTML
     wizard.attr("role", "application").empty().append(stepsWrapper).append(contentWrapper)

--- a/test/index.html
+++ b/test/index.html
@@ -57,6 +57,7 @@
 		</div>
 		<script src="qunit/qunit-1.11.0.js"></script>
 		<script src="tests.js"></script>
+		<script src="semantic_form_tests.js"></script>
 		<script src="jquery.js"></script>
 		<script src="../build/jquery.steps.js"></script>
 		<script src="../src/privates.js"></script>

--- a/test/semantic_form_tests.js
+++ b/test/semantic_form_tests.js
@@ -16,19 +16,16 @@ test("contentMode", 5, function ()
     equal(contentModeWithStringArgument.steps("getCurrentStep").contentMode, 0, "Valid string argument");
 });
 
-module("visualization", {
+module("semantic form visualization", {
     setup: function ()
     {
         $("#qunit-fixture").append($("<div id=\"vis\">" +
-                "<h1>First</h1>" +
-                "<div>Content 1</div>" +
-                "<h1>Second</h1>" +
-                "<div>Content 2</div>" +
-                "<h1>Third</h1>" +
-                "<div>Content 3</div>" +
+                "<fieldset><legend>First</legend>Content 1</fieldset>" +
+                "<fieldset><legend>Second</legend>Content 2</fieldset>" +
+                "<fieldset><legend>Third</legend>Content 3</fieldset>" +
             "</div>"));
 
-        $("#vis").steps();
+        $("#vis").steps({ 'headerTag': 'fieldset legend', 'bodyTag': 'fieldset' });
     },
     teardown: function ()
     {
@@ -245,4 +242,3 @@ test("uniqueId", 5, function ()
 
     wizard2.steps("destroy").remove();
 });
-


### PR DESCRIPTION
I'm using [formtastic](https://github.com/justinfrench/formtastic) in a Rails app, and wanted to add jquery.steps to one of my forms, but i found some difficulties since this forces forms to have the following structure:

``` html
<form>
  <titleTag>Title 1</titleTag>
  <bodyTag>Content 1</bodyTag>

  <titleTag>Title 2</titleTag>
  <bodyTag>Content 2</bodyTag>
</form>
```

while I usually prefer a more structured option, pretty much like the default one that formtastic does for me on this specific case:

``` html
<form>
  <bodyTag>
    <titleTag>Title 1</titleTag>
    Content 1
  </bodyTag>

  <bodyTag>
    <titleTag>Title 2</titleTag>
    Content 2
  </bodyTag>
</form>
```

The only thing preventing jquery.steps from handling this was because it was using `children()` to find all titles and bodies. Switching to the `find` method allowed to use nested selectors such as this:

``` javascript
$('#new_user').steps({
  'headerTag': 'fieldset legend',
  'bodyTag': 'fieldset'
});
```

and everything else seems to work fine.
I just didn't know how to go about the test suite, since i have 0 experience with QUnit. My (stupid) approach was to just duplicate the original tests, but this time isung a form with the newly supported structure
There's got to be a better way to test this though...
