### PR TITLE
Update package.json with main key

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "title": "jQuery Steps",
   "version": "1.1.0",
   "description": "A powerful jQuery wizard plugin that supports accessibility and HTML5",
+  "main": "build/jquery.steps.js",
   "homepage": "http://www.jquery-steps.com",
   "author": {
     "name": "Rafael Staib",


### PR DESCRIPTION
Adding the main key into the package.json file will allow Webpack to automatically find the main JavaScript file to import when using Babel.
