### PR TITLE
changed the render function to preserve the initial nodes when copying…

### DIFF
--- a/src/privates.js
+++ b/src/privates.js
@@ -936,7 +936,7 @@ function render(wizard, options, state)
     var wrapperTemplate = "<{0} class=\"{1}\">{2}</{0}>",
         orientation = getValidEnumValue(stepsOrientation, options.stepsOrientation),
         verticalCssClass = (orientation === stepsOrientation.vertical) ? " vertical" : "",
-        contentWrapper = $(wrapperTemplate.format(options.contentContainerTag, "content " + options.clearFixCssClass, wizard.html())),
+        contentWrapper = $(wrapperTemplate.format(options.contentContainerTag, "content " + options.clearFixCssClass)).html("").append(wizard.find(">")),
         stepsWrapper = $(wrapperTemplate.format(options.stepsContainerTag, "steps " + options.clearFixCssClass, "<ul role=\"tablist\"></ul>")),
         stepTitles = contentWrapper.children(options.headerTag),
         stepContents = contentWrapper.children(options.bodyTag);


### PR DESCRIPTION
When using strings, if there are any events or data attached to the HTML nodes before you init the steps plugin, those events and data will be lost.
I've modified the render function so that it copies the DOM objects, instead of converting the html to a string and re-parsing it as DOM objects.
