### PR TITLE
Browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jquery-steps",
   "title": "jQuery Steps",
   "version": "1.1.0",
+  "main": "build/jquery.steps.js",
   "description": "A powerful jQuery wizard plugin that supports accessibility and HTML5",
   "homepage": "http://www.jquery-steps.com",
   "author": {


### PR DESCRIPTION
I ran into an issue trying to require the jquery-steps module in my app.js on my Laravel 5.2 project. Turns out all that was needed was a declaration of the main file in the `package.json` file.
